### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/176/817/421176817.geojson
+++ b/data/421/176/817/421176817.geojson
@@ -554,6 +554,9 @@
     },
     "wof:country":"SL",
     "wof:created":1459009120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57d8fa65f49e08d77449079503bcb620",
     "wof:hierarchy":[
         {
@@ -565,7 +568,7 @@
         }
     ],
     "wof:id":421176817,
-    "wof:lastmodified":1566647392,
+    "wof:lastmodified":1582381162,
     "wof:name":"Freetown",
     "wof:parent_id":1108779071,
     "wof:placetype":"locality",

--- a/data/856/324/67/85632467.geojson
+++ b/data/856/324/67/85632467.geojson
@@ -975,6 +975,11 @@
     },
     "wof:country":"SL",
     "wof:country_alpha3":"SLE",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"e8888e7d27102316d884c482bb1c505a",
     "wof:hierarchy":[
         {
@@ -989,7 +994,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566646453,
+    "wof:lastmodified":1582381143,
     "wof:name":"Sierra Leone",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/771/19/85677119.geojson
+++ b/data/856/771/19/85677119.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Southern Province, Sierra Leone"
     },
     "wof:country":"SL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ce6b8d972e391eb789d686342088766",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566646456,
+    "wof:lastmodified":1582381146,
     "wof:name":"Southern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/23/85677123.geojson
+++ b/data/856/771/23/85677123.geojson
@@ -252,6 +252,9 @@
         "wk:page":"Western Area"
     },
     "wof:country":"SL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ee6f60bf6401ed01de0a0eeabb7e90eb",
     "wof:hierarchy":[
         {
@@ -267,7 +270,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566646456,
+    "wof:lastmodified":1582381147,
     "wof:name":"Western",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/27/85677127.geojson
+++ b/data/856/771/27/85677127.geojson
@@ -292,6 +292,9 @@
         "wd:id":"Q912359"
     },
     "wof:country":"SL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6344b13d68ea9a23f0a1ef097925bb0d",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566646455,
+    "wof:lastmodified":1582381146,
     "wof:name":"Northern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/33/85677133.geojson
+++ b/data/856/771/33/85677133.geojson
@@ -289,6 +289,9 @@
         "wd:id":"Q1050497"
     },
     "wof:country":"SL",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3cc58d7f335d6afe47d65f04d20ec196",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566646454,
+    "wof:lastmodified":1582381145,
     "wof:name":"Eastern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/890/421/467/890421467.geojson
+++ b/data/890/421/467/890421467.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051394,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ae0e219d715045223c9a65cb632b7344",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890421467,
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582381163,
     "wof:name":"Tonkolili",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/421/469/890421469.geojson
+++ b/data/890/421/469/890421469.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051394,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8230c828c21187595349b0eb40bc114d",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":890421469,
-    "wof:lastmodified":1566647397,
+    "wof:lastmodified":1582381163,
     "wof:name":"Kono",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/421/473/890421473.geojson
+++ b/data/890/421/473/890421473.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051394,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c131280dfbf215f2f462b944c7a476b2",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890421473,
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582381163,
     "wof:name":"Koinadugu",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/421/475/890421475.geojson
+++ b/data/890/421/475/890421475.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051394,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a4426a0348f90bb429d2467a80a252ed",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890421475,
-    "wof:lastmodified":1566647396,
+    "wof:lastmodified":1582381162,
     "wof:name":"Kailahun",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/428/991/890428991.geojson
+++ b/data/890/428/991/890428991.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051786,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c30db5d3e79cf6e4b74f248f07142c2",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":890428991,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582381164,
     "wof:name":"Bonthe",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/890/428/993/890428993.geojson
+++ b/data/890/428/993/890428993.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051786,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"23cfbe7ec17a3bc1d30bbeae824426a0",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890428993,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582381164,
     "wof:name":"Bombali",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/428/997/890428997.geojson
+++ b/data/890/428/997/890428997.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469051786,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4113d493cb443856973fee124cc6d964",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":890428997,
-    "wof:lastmodified":1566647398,
+    "wof:lastmodified":1582381164,
     "wof:name":"Bo",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/890/453/879/890453879.geojson
+++ b/data/890/453/879/890453879.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469052876,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d130b898e8942d14b254089cde39dfc4",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":890453879,
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582381162,
     "wof:name":"Kenema",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/453/881/890453881.geojson
+++ b/data/890/453/881/890453881.geojson
@@ -125,6 +125,9 @@
     },
     "wof:country":"SL",
     "wof:created":1469052876,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7510bcd5cdae56ac27b992e3b27000f",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":890453881,
-    "wof:lastmodified":1566647395,
+    "wof:lastmodified":1582381162,
     "wof:name":"Kambia",
     "wof:parent_id":85677127,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.