### PR TITLE
Name updates

### DIFF
--- a/data/112/591/381/9/1125913819.geojson
+++ b/data/112/591/381/9/1125913819.geojson
@@ -128,7 +128,7 @@
         "\u06a9\u0627\u0645\u0628\u06cc\u0627 \u060c \u0633\u06cc\u0631\u0627\u0621 \u0644\u06cc\u0648\u0646\u06cc"
     ],
     "name:urd_x_variant":[
-        "\u06a9\u0627\u0645\u0628\u06cc\u0627 "
+        "\u06a9\u0627\u0645\u0628\u06cc\u0627"
     ],
     "name:vie_x_preferred":[
         "Kambia"
@@ -153,8 +153,8 @@
     "wof:belongsto":[
         102191573,
         85632467,
-        85677127,
-        890453881
+        890453881,
+        85677127
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -175,7 +175,7 @@
         }
     ],
     "wof:id":1125913819,
-    "wof:lastmodified":1566647404,
+    "wof:lastmodified":1587163114,
     "wof:name":"Kambia",
     "wof:parent_id":890453881,
     "wof:placetype":"locality",

--- a/data/421/193/955/421193955.geojson
+++ b/data/421/193/955/421193955.geojson
@@ -111,7 +111,7 @@
         "\u0bb5\u0bbe\u0b9f\u0bcd\u0b9f\u0bb0\u0bcd\u0bb2\u0bc2"
     ],
     "name:tam_x_variant":[
-        "\u0bb5\u0bbe\u0b9f\u0bcd\u0b9f\u0bb0\u0bcd\u0bb2\u0bc2 "
+        "\u0bb5\u0bbe\u0b9f\u0bcd\u0b9f\u0bb0\u0bcd\u0bb2\u0bc2"
     ],
     "name:tel_x_preferred":[
         "\u0c35\u0c3e\u0c1f\u0c30\u0c4d\u0c32\u0c42"
@@ -158,8 +158,8 @@
     "wof:belongsto":[
         102191573,
         85632467,
-        85677123,
-        1108779071
+        1108779071,
+        85677123
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -182,7 +182,7 @@
         }
     ],
     "wof:id":421193955,
-    "wof:lastmodified":1566647390,
+    "wof:lastmodified":1587163137,
     "wof:name":"Waterloo",
     "wof:parent_id":1108779071,
     "wof:placetype":"locality",

--- a/data/856/324/67/85632467.geojson
+++ b/data/856/324/67/85632467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.953558,
-    "geom:area_square_m":72791067427.643326,
+    "geom:area_square_m":72791068968.993073,
     "geom:bbox":"-13.302072,6.921616,-10.271683,9.999973",
     "geom:latitude":8.559959,
     "geom:longitude":-11.789689,
@@ -55,6 +55,9 @@
     "name:arg_x_preferred":[
         "Sierra Leone"
     ],
+    "name:ary_x_preferred":[
+        "\u0633\u064a\u064a\u0631\u0627 \u0644\u064a\u0648\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u0633\u064a\u064a\u0631\u0627\u0644\u064a\u0648\u0646"
     ],
@@ -81,6 +84,9 @@
     ],
     "name:bam_x_variant":[
         "Siyera Lew\u0254ni"
+    ],
+    "name:ban_x_preferred":[
+        "Sierra Leone"
     ],
     "name:bcl_x_preferred":[
         "Sierra Leona"
@@ -151,6 +157,12 @@
     "name:dan_x_preferred":[
         "Sierra Leone"
     ],
+    "name:deu_at_x_preferred":[
+        "Sierra Leone"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Sierra Leone"
+    ],
     "name:deu_x_preferred":[
         "Sierra Leone"
     ],
@@ -168,6 +180,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a3\u03b9\u03ad\u03c1\u03b1 \u039b\u03b5\u03cc\u03bd\u03b5"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Sierra Leone"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Sierra Leone"
     ],
     "name:eng_x_preferred":[
         "Sierra Leone"
@@ -238,6 +256,9 @@
     ],
     "name:gag_x_preferred":[
         "Syerra Leone"
+    ],
+    "name:gcr_x_preferred":[
+        "Sy\u00e9ra L\u00e9onn"
     ],
     "name:ger_x_variant":[
         "Republik Sierra Leone"
@@ -496,6 +517,9 @@
     "name:mon_x_preferred":[
         "\u0421\u044c\u0435\u0440\u0440\u0430-\u041b\u0435\u043e\u043d\u0435"
     ],
+    "name:mri_x_preferred":[
+        "Te Araone"
+    ],
     "name:mrj_x_preferred":[
         "\u0421\u044c\u0435\u0440\u0440\u0430-\u041b\u0435\u043e\u043d\u0435"
     ],
@@ -553,6 +577,9 @@
     "name:nov_x_preferred":[
         "Siera Leone"
     ],
+    "name:nqo_x_preferred":[
+        "\u07db\u07d9\u07ca\u07ec\u07df\u07cf\u07f2\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Sierra Leone"
     ],
@@ -597,6 +624,9 @@
     ],
     "name:pol_x_preferred":[
         "Sierra Leone"
+    ],
+    "name:por_br_x_preferred":[
+        "Serra Leoa"
     ],
     "name:por_x_preferred":[
         "Serra Leoa"
@@ -649,8 +679,20 @@
     "name:sme_x_preferred":[
         "Sierra Leone"
     ],
+    "name:smn_x_preferred":[
+        "Sierra Leone"
+    ],
+    "name:smo_x_preferred":[
+        "Sierra Leone"
+    ],
+    "name:sms_x_preferred":[
+        "Sierra Leone"
+    ],
     "name:sna_x_preferred":[
         "Sierra Leone"
+    ],
+    "name:snd_x_preferred":[
+        "\u0633\u064a\u0631\u0627 \u0644\u064a\u0648\u0646"
     ],
     "name:som_x_preferred":[
         "Sierra Leone"
@@ -669,6 +711,12 @@
     ],
     "name:srd_x_preferred":[
         "Sierra Leone"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0421\u0438\u0458\u0435\u0440\u0430 \u041b\u0435\u043e\u043d\u0435"
+    ],
+    "name:srp_el_x_preferred":[
+        "Sijera Leone"
     ],
     "name:srp_x_preferred":[
         "\u0421\u0438\u0458\u0435\u0440\u0430 \u041b\u0435\u043e\u043d\u0435"
@@ -828,8 +876,26 @@
     "name:zha_x_preferred":[
         "Sierra Leone"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u585e\u62c9\u5229\u6602"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u585e\u62c9\u5229\u6602"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Sierra Leone"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u585e\u62c9\u5229\u6602"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u585e\u62c9\u5229\u6602"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u585e\u62c9\u5229\u6602"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u7345\u5b50\u5c71"
     ],
     "name:zho_x_preferred":[
         "\u585e\u62c9\u5229\u6602"
@@ -995,7 +1061,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1583797431,
+    "wof:lastmodified":1587427894,
     "wof:name":"Sierra Leone",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.