### PR TITLE
sl concordances, placetype local, and more

### DIFF
--- a/data/110/877/906/5/1108779065.geojson
+++ b/data/110/877/906/5/1108779065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.485061,
-    "geom:area_square_m":5928396620.21369,
+    "geom:area_square_m":5928396620.213737,
     "geom:bbox":"-13.267944336,8.26629818218,-12.2839929512,9.27692396882",
     "geom:latitude":8.72681,
     "geom:longitude":-12.742277,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"SL.NO.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1481737149,
-    "wof:geomhash":"3e456e654941e28ec91dcb089850bf87",
+    "wof:geomhash":"a248879750a503510085843efc795e85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108779065,
-    "wof:lastmodified":1566647131,
+    "wof:lastmodified":1695886414,
     "wof:name":"Port Loko",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/110/877/906/7/1108779067.geojson
+++ b/data/110/877/906/7/1108779067.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.560787,
-    "geom:area_square_m":6865697319.197329,
+    "geom:area_square_m":6865697319.197335,
     "geom:bbox":"-13.009583473,7.65258953131,-11.8036629279,8.38635226996",
     "geom:latitude":8.06064,
     "geom:longitude":-12.435148,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SL.SO.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1481737153,
-    "wof:geomhash":"88f7414ff24c54124d0c88107dacf06f",
+    "wof:geomhash":"a1319d19c0f3bb408b23c2521ee58666",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108779067,
-    "wof:lastmodified":1566647131,
+    "wof:lastmodified":1695886415,
     "wof:name":"Moyamba",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/110/877/906/9/1108779069.geojson
+++ b/data/110/877/906/9/1108779069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319232,
-    "geom:area_square_m":3915401229.524378,
+    "geom:area_square_m":3915401229.524286,
     "geom:bbox":"-11.9360999637,6.921616,-11.1637591801,7.65689763131",
     "geom:latitude":7.295355,
     "geom:longitude":-11.582463,
@@ -87,9 +87,10 @@
     "wof:concordances":{
         "hasc:id":"SL.SO.PU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1481737154,
-    "wof:geomhash":"eb768c87862ddb0afac3dbf62951d2bb",
+    "wof:geomhash":"7364ee012f233fa03234eda84e1f9b7a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -99,7 +100,7 @@
         }
     ],
     "wof:id":1108779069,
-    "wof:lastmodified":1566647130,
+    "wof:lastmodified":1695886414,
     "wof:name":"Pujehun",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/110/877/907/1/1108779071.geojson
+++ b/data/110/877/907/1/1108779071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056259,
-    "geom:area_square_m":688300433.000874,
+    "geom:area_square_m":688300707.527443,
     "geom:bbox":"-13.300445,8.092055,-12.924117,8.497916",
     "geom:latitude":8.33851,
     "geom:longitude":-13.115795,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"SL.WE.WR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1481737156,
-    "wof:geomhash":"bb149ebeea8a68d9ff133a550775c5df",
+    "wof:geomhash":"608b429028673f1db92a82fb83c502ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108779071,
-    "wof:lastmodified":1627522782,
+    "wof:lastmodified":1695886477,
     "wof:name":"Western Area",
     "wof:parent_id":85677123,
     "wof:placetype":"county",

--- a/data/856/324/67/85632467.geojson
+++ b/data/856/324/67/85632467.geojson
@@ -1165,6 +1165,7 @@
         "hasc:id":"SL",
         "icao:code":"9L",
         "ioc:id":"SLE",
+        "iso:code":"SL",
         "itu:id":"SRL",
         "m49:code":"694",
         "marc:id":"sl",
@@ -1178,6 +1179,7 @@
         "wk:page":"Sierra Leone",
         "wmo:id":"SL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SL",
     "wof:country_alpha3":"SLE",
     "wof:geom_alt":[
@@ -1199,7 +1201,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639571,
+    "wof:lastmodified":1695881231,
     "wof:name":"Sierra Leone",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/771/19/85677119.geojson
+++ b/data/856/771/19/85677119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.62568,
-    "geom:area_square_m":19916358120.999699,
+    "geom:area_square_m":19916357841.255112,
     "geom:bbox":"-13.083777,6.921616,-11.163759,8.487119",
     "geom:latitude":7.781492,
     "geom:longitude":-12.041911,
@@ -290,17 +290,19 @@
         "gn:id":2403745,
         "gp:id":2347002,
         "hasc:id":"SL.SO",
+        "iso:code":"SL-S",
         "iso:id":"SL-S",
         "qs_pg:id":901872,
         "unlc:id":"SL-S",
         "wd:id":"Q772185",
         "wk:page":"Southern Province, Sierra Leone"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e62e07388e31a4b99da0cae6c434768d",
+    "wof:geomhash":"72996db14428ca4a0347136f7772d4b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690865772,
+    "wof:lastmodified":1695884963,
     "wof:name":"Southern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/23/85677123.geojson
+++ b/data/856/771/23/85677123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056259,
-    "geom:area_square_m":688300433.000893,
+    "geom:area_square_m":688300707.527443,
     "geom:bbox":"-13.300445,8.092055,-12.924117,8.497916",
     "geom:latitude":8.33851,
     "geom:longitude":-13.115795,
@@ -276,16 +276,18 @@
         "gn:id":2403068,
         "gp:id":2347003,
         "hasc:id":"SL.WE",
+        "iso:code":"SL-W",
         "iso:id":"SL-W",
         "qs_pg:id":901873,
         "wd:id":"Q1050475",
         "wk:page":"Western Area"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bb149ebeea8a68d9ff133a550775c5df",
+    "wof:geomhash":"608b429028673f1db92a82fb83c502ee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690865773,
+    "wof:lastmodified":1695884963,
     "wof:name":"Western",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/27/85677127.geojson
+++ b/data/856/771/27/85677127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.961454,
-    "geom:area_square_m":36153175651.544304,
+    "geom:area_square_m":36153176395.936646,
     "geom:bbox":"-13.302072,8.245939,-10.57351,9.999973",
     "geom:latitude":9.138196,
     "geom:longitude":-11.97994,
@@ -299,16 +299,18 @@
         "gn:id":2404798,
         "gp:id":2347001,
         "hasc:id":"SL.NO",
+        "iso:code":"SL-N",
         "iso:id":"SL-N",
         "qs_pg:id":900757,
         "unlc:id":"SL-N",
         "wd:id":"Q912359"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c7e2fb52d4e33700d136c296b92a64fe",
+    "wof:geomhash":"38d0b8b20470dfe26317ca81432dbf96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690865772,
+    "wof:lastmodified":1695884963,
     "wof:name":"Northern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/856/771/33/85677133.geojson
+++ b/data/856/771/33/85677133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.310165,
-    "geom:area_square_m":16033233231.613398,
+    "geom:area_square_m":16033234062.595333,
     "geom:bbox":"-11.60692,7.305872,-10.271683,9.063074",
     "geom:latitude":8.22838,
     "geom:longitude":-10.989745,
@@ -304,16 +304,18 @@
         "gn:id":2409543,
         "gp:id":2347000,
         "hasc:id":"SL.EA",
+        "iso:code":"SL-E",
         "iso:id":"SL-E",
         "qs_pg:id":900756,
         "unlc:id":"SL-E",
         "wd:id":"Q1050497"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SL",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b2dc692c927dec17d9eda633b7de132",
+    "wof:geomhash":"161cab2a904c06f361d610d2abd0d062",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690865771,
+    "wof:lastmodified":1695884963,
     "wof:name":"Eastern",
     "wof:parent_id":85632467,
     "wof:placetype":"region",

--- a/data/890/421/467/890421467.geojson
+++ b/data/890/421/467/890421467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.52864,
-    "geom:area_square_m":6462133120.397492,
+    "geom:area_square_m":6462134011.336472,
     "geom:bbox":"-12.687319,8.245939,-11.345747,9.276502",
     "geom:latitude":8.661609,
     "geom:longitude":-11.885933,
@@ -129,12 +129,13 @@
         "wd:id":"Q1852020",
         "wk:page":"Tonkolili District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051394,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"635beb4fab04b9384cb9b85c425dac28",
+    "wof:geomhash":"aeb1f6c0c5258b6f73cd291548ee9c20",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":890421467,
-    "wof:lastmodified":1690865783,
+    "wof:lastmodified":1695886067,
     "wof:name":"Tonkolili",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/421/469/890421469.geojson
+++ b/data/890/421/469/890421469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.452917,
-    "geom:area_square_m":5536134203.739595,
+    "geom:area_square_m":5536134710.397846,
     "geom:bbox":"-11.364404,8.323255,-10.464392,9.063074",
     "geom:latitude":8.686968,
     "geom:longitude":-10.94595,
@@ -135,12 +135,13 @@
         "wd:id":"Q1781849",
         "wk:page":"Kono District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051394,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89ea7a0448f0e60cc262e23584adacaa",
+    "wof:geomhash":"509a17e6f07824c4e4c33a403cd83ddc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":890421469,
-    "wof:lastmodified":1690865783,
+    "wof:lastmodified":1695886475,
     "wof:name":"Kono",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/421/473/890421473.geojson
+++ b/data/890/421/473/890421473.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.024657,
-    "geom:area_square_m":12497899541.826204,
+    "geom:area_square_m":12497899637.261509,
     "geom:bbox":"-12.132388,8.643762,-10.57351,9.999973",
     "geom:latitude":9.452121,
     "geom:longitude":-11.344677,
@@ -126,12 +126,13 @@
         "wd:id":"Q1778860",
         "wk:page":"Koinadugu District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051394,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27595f5615a51a084ed02ce83a1167db",
+    "wof:geomhash":"1c8e72e742989aa4d1021304cbe6208c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":890421473,
-    "wof:lastmodified":1690865783,
+    "wof:lastmodified":1695886476,
     "wof:name":"Koinadugu",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/421/475/890421475.geojson
+++ b/data/890/421/475/890421475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.342525,
-    "geom:area_square_m":4193291055.2938,
+    "geom:area_square_m":4193291546.855626,
     "geom:bbox":"-11.064036,7.590616,-10.271683,8.50595",
     "geom:latitude":8.082531,
     "geom:longitude":-10.709384,
@@ -126,12 +126,13 @@
         "wd:id":"Q1721443",
         "wk:page":"Kailahun District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051394,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4d5edb3bfbf277e043b46918d9f2ff2",
+    "wof:geomhash":"a616674105bfd5541578cc7e047ceb07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":890421475,
-    "wof:lastmodified":1690865782,
+    "wof:lastmodified":1695886474,
     "wof:name":"Kailahun",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/428/991/890428991.geojson
+++ b/data/890/428/991/890428991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284107,
-    "geom:area_square_m":3482979381.564061,
+    "geom:area_square_m":3482979493.122859,
     "geom:bbox":"-13.083777,7.176311,-11.872991,7.803881",
     "geom:latitude":7.499622,
     "geom:longitude":-12.287398,
@@ -129,12 +129,13 @@
         "wd:id":"Q892889",
         "wk:page":"Bonthe District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051786,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"509c2b3924f7cfb1adcf70c3fb90dee2",
+    "wof:geomhash":"1fef7c71b94035142a895869cac982a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":890428991,
-    "wof:lastmodified":1690865784,
+    "wof:lastmodified":1695886474,
     "wof:name":"Bonthe",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/890/428/993/890428993.geojson
+++ b/data/890/428/993/890428993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.678523,
-    "geom:area_square_m":8279368092.564263,
+    "geom:area_square_m":8279368177.345926,
     "geom:bbox":"-12.58764,8.637503,-11.757771,9.936167",
     "geom:latitude":9.311474,
     "geom:longitude":-12.169643,
@@ -126,12 +126,13 @@
         "wd:id":"Q891767",
         "wk:page":"Bombali District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051786,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47c06a5fff2e3191399e320273dbb675",
+    "wof:geomhash":"91e36c37cfe489d83bdbd70d757af49b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":890428993,
-    "wof:lastmodified":1690865784,
+    "wof:lastmodified":1695886475,
     "wof:name":"Bombali",
     "wof:parent_id":85677127,
     "wof:placetype":"county",

--- a/data/890/428/997/890428997.geojson
+++ b/data/890/428/997/890428997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.461554,
-    "geom:area_square_m":5652280190.714511,
+    "geom:area_square_m":5652280312.372889,
     "geom:bbox":"-12.167936,7.486942,-11.352076,8.487119",
     "geom:latitude":7.952068,
     "geom:longitude":-11.730798,
@@ -126,12 +126,13 @@
         "wd:id":"Q887317",
         "wk:page":"Bo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469051786,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8038eb290712c79dce5ea20908ff1381",
+    "wof:geomhash":"2dbcec13514f2628d74158eca32ccc8d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":890428997,
-    "wof:lastmodified":1636505027,
+    "wof:lastmodified":1695886167,
     "wof:name":"Bo",
     "wof:parent_id":85677119,
     "wof:placetype":"county",

--- a/data/890/453/879/890453879.geojson
+++ b/data/890/453/879/890453879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.514723,
-    "geom:area_square_m":6303807972.581443,
+    "geom:area_square_m":6303807869.44591,
     "geom:bbox":"-11.60692,7.305872,-10.813632,8.534113",
     "geom:latitude":7.921913,
     "geom:longitude":-11.214851,
@@ -132,12 +132,13 @@
         "wd:id":"Q1738741",
         "wk:page":"Kenema District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469052876,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b406ebde0eb6a6ca7322ca4321bc5d20",
+    "wof:geomhash":"ea3ad03a45e1d21f3664aeabbdd9bf60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":890453879,
-    "wof:lastmodified":1690865782,
+    "wof:lastmodified":1695886167,
     "wof:name":"Kenema",
     "wof:parent_id":85677133,
     "wof:placetype":"county",

--- a/data/890/453/881/890453881.geojson
+++ b/data/890/453/881/890453881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.244573,
-    "geom:area_square_m":2985378276.544214,
+    "geom:area_square_m":2985378112.807357,
     "geom:bbox":"-13.302072,8.836682,-12.371068,9.611999",
     "geom:latitude":9.188292,
     "geom:longitude":-12.806376,
@@ -132,12 +132,13 @@
         "wd:id":"Q1722895",
         "wk:page":"Kambia District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SL",
     "wof:created":1469052876,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"386549ea255cb22f0f33a05e37c71383",
+    "wof:geomhash":"9e03b89ab174e51daa81537f5cde0b0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":890453881,
-    "wof:lastmodified":1690865782,
+    "wof:lastmodified":1695886475,
     "wof:name":"Kambia",
     "wof:parent_id":85677127,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.